### PR TITLE
Add troubleshooting details for XCode 10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,10 @@ $ open ./android/app/build/outputs/apk
 [React native docs for IOS](http://facebook.github.io/react-native/releases/0.49/docs/running-on-device.html#building-your-app-for-production)
 
 ## Troubleshooting
-Issues with Xcode 10 (newest version) - https://github.com/facebook/react-native/issues/19573
+### XCode 10
+See [crnwa-xcode-patch](https://github.com/closetothe/create-react-native-web-app) for a summary of how to fix the two known issues caused by XCode 10.x. For more detail, see [`react-native` issue #19573](https://github.com/facebook/react-native/issues/19573).  
 
+### Android
 If you got `Execution failed for task ':app:compileDebugAidl'` when running `yarn android`, try to update Android Gradle plugin to version 3.1.1 and Gradle to version 4.4.
 
 Here is how to do that:


### PR DESCRIPTION
As is, you can't use CRNWA with XCode 10.x for two reasons:
1. The build system has changed. This can be fixed by using the legacy build system as described in [`react-native` issue #19573](https://github.com/facebook/react-native/issues/19573).
2. The naming convention for devices has changed, so the `findMatchingSimulators.js` script in `react-native` doesn't work.
I've described it in more detail [here](https://github.com/closetothe/crnwa-xcode-patch).

I realize that this is a problem with `react-native` that has been solved in more recent releases. However, since we need to use version 0.55 for `react-native-web`, the issue will be here for a while. **I propose that we add a link to [my relevant repo](https://github.com/closetothe/crnwa-xcode-patch) to the Troubleshooting section of the readme, since it explains exactly how to fix both problems.**
