### PR TITLE
Fix template renaming on Windows

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -68,7 +68,7 @@ if (appName) {
   // install deps
   printCyan("⏳ Installing project dependencies...");
   console.log();
-  let command = `cd ${appName} && npx react-native-rename ${appName} && `;
+  let command = `cd ${appName} && npx react-native-rename-next ${appName} && `;
   let args;
   if (isYarnAvailable) {
     command += "yarn";


### PR DESCRIPTION
The react-native-rename module is bugged and deletes the Java files on Windows.
The react-native-rename-next module has a fix for that.